### PR TITLE
fix: update App.jsx to use w-32 h-32 for service icons (2x size)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,7 +83,7 @@ function Services() {
         {items.map((x, i) => (
           <div key={i} className="card">
             <div className="flex justify-center">
-              <ServiceIcons serviceType={x.icon} className="w-16 h-16" />
+              <ServiceIcons serviceType={x.icon} className="w-32 h-32" />
             </div>
             <h3 className="mt-3 font-semibold">{x.title}</h3>
             <p className="mt-2 text-white/70 text-sm leading-relaxed">


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: what changed -->

## Changes
- [ ] UI: …
- [ ] Logic: …
- [ ] Styles/Tailwind: …
- [ ] Config: …

## Acceptance Criteria
- [ ] Build passes locally (`npm run build`)
- [ ] No new deps added
- [ ] No CLS; header/footer stable
- [ ] Accessible focus states

## Screenshots / Diffs
<!-- attach screenshot or diff summary -->

## Checklist
- [ ] Small, atomic PR (<200 lines)
- [ ] Updated docs if needed
- [ ] Linked issue (if exists): #123

## Reviewer Notes
<!-- steps for reviewer to verify -->
